### PR TITLE
Jest config for typescript

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,9 @@
+import type { Config } from '@jest/types';
+// Sync object
+const config: Config.InitialOptions = {
+  verbose: true,
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest',
+  },
+};
+export default config;

--- a/package.json
+++ b/package.json
@@ -7,12 +7,10 @@
   "license": "MIT",
   "scripts": {
     "start": "nodemon src/app.ts",
-    "test": "yarn validate && jest --passWithNoTests",
+    "test": "jest",
     "lint": "eslint --ignore-path .gitignore",
     "format": "prettier --ignore-path .gitignore --write \"**/*.+(js|json)\"",
-    "validate": "yarn format && yarn lint",
-    "validate-staged": "lint-staged",
-    "postinstall": "husky install && husky add .husky/pre-commit \"yarn validate-staged\" && husky add .husky/pre-push \"yarn test\""
+    "validate-staged": "lint-staged"
   },
   "dependencies": {
     "bcrypt": "^5.1.0",
@@ -25,6 +23,7 @@
     "mongoose": "^7.3.3",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.0",
+    "ts-jest": "^29.1.1",
     "yarn-upgrade-all": "^0.6.1"
   },
   "devDependencies": {
@@ -52,7 +51,6 @@
     "lint-staged": "^12.5.0",
     "nodemon": "^2.0.15",
     "prettier": "^2.5.1",
-    "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
     "typescript": "^5.1.6"
   }


### PR DESCRIPTION

I have added the jest.config.ts file which is responsible to transpile all .ts files in the project, we have to add that since we are using typescript, otherwise, jest will not work.

I also deleted all the commands in package.json that have `yarn` since we already deleted it.

